### PR TITLE
Added a file to allow ng-bind-polymer to be used with ES6 style imports.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+import angular from 'angular';
+import * as ngBindPolymer from './ng-bind-polymer';
+
+export default ngBindPolymer;


### PR DESCRIPTION
Makes it a bit easier to use ng-bind-polymer with ES6 projects that are importing Angular with the ES6 import conventions.
